### PR TITLE
Fail UX2.0 playbooks if vmanage version is lower than required

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -50,6 +50,7 @@ mock_roles:
   - cisco.catalystwan.sync_pnp_edges
   - cisco.catalystwan.activate_edges
   - cisco.catalystwan.vmanage_mode
+  - cisco.catalystwan.vmanage_version
   - cisco.catalystwan.health_checks
   - cisco.catalystwan.config_groups
   - cisco.catalystwan.feature_profile_builder

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: cisco
 name: sdwan
-version: 0.3.4
+version: 0.3.5
 readme: README.md
 authors:
   - Arkadiusz Cichon <acichon@cisco.com>

--- a/playbooks/aws/ux2_full_deploy_and_configure.yml
+++ b/playbooks/aws/ux2_full_deploy_and_configure.yml
@@ -63,16 +63,25 @@
 
 
 # Attach templates with running-config for all devices
-- name: Set vmanage mode for all devices
+- name: Set vmanage mode for controllers
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - ./dev_config_aws.yml
+    - "{{ results_path_controllers }}"
+  roles:
+    - cisco.catalystwan.vmanage_mode
+
+- name: Check if vManage version matches requirements
   hosts: localhost
   gather_facts: false
   vars_files:
     - ./dev_config_aws.yml
     - "{{ results_path_controllers }}"
   vars:
-    edge_instances: "{{ deployed_edge_instances }}"
+    min_version_required: "20.13.1"
   roles:
-    - cisco.catalystwan.vmanage_mode
+    - cisco.catalystwan.vmanage_version
 
 - name: Build feature profile data
   hosts: localhost

--- a/playbooks/azure/ux2_full_deploy_and_configure.yml
+++ b/playbooks/azure/ux2_full_deploy_and_configure.yml
@@ -80,6 +80,17 @@
   roles:
     - cisco.catalystwan.feature_profile_builder
 
+- name: Check if vManage version matches requirements
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - ./azure_sdwan_config.yml
+    - "{{ results_path_controllers }}"
+  vars:
+    min_version_required: "20.13.1"
+  roles:
+    - cisco.catalystwan.vmanage_version
+
 - name: Create Config Groups
   hosts: localhost
   gather_facts: false

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,6 +4,6 @@ collections:
   - name: azure.azcollection
     version: 1.19.0
   - name: cisco.catalystwan
-    version: 0.3.1
+    version: 0.3.2
   - name: cisco.sdwan_deployment
     version: 0.3.3


### PR DESCRIPTION
# Pull Request summary:
Fail UX2.0 playbooks if vmanage version is lower than required. Currently 20.13.1.

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Make sure you test the changes
