### PR TITLE
Update software_upgrades playbook to new role name

### DIFF
--- a/playbooks/software_upgrades_with_remote_server.yml
+++ b/playbooks/software_upgrades_with_remote_server.yml
@@ -21,4 +21,4 @@
     edge_software_version_to_activate: null  # For Remote Images that don't report its version in repository, we have to provide that value directly
     remove_available_software_from_device: true
   roles:
-    - cisco.catalystwan.software_upgrades_remote
+    - cisco.catalystwan.software_upgrades


### PR DESCRIPTION
# Pull Request summary:
software_upgrades_remote role was expanded to cover upgrades without remote server. Role name was adjusted to reflect that

# Description of changes:
cisco.catalystwan.software_upgrades_remote role was renamed to cisco.catalystwan.software_upgrades

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
