### PR TITLE
AWS: Allow the deployment of a subset of edges

### DIFF
--- a/playbooks/aws/aws_sdwan_config.yml
+++ b/playbooks/aws/aws_sdwan_config.yml
@@ -90,6 +90,24 @@ aws_cedge_instance_type: "c5.large"
 # based on the PnP Portal information.
 # See `deployment_edges_config` to inspect result
 
+# wan_edges parameter is an optional list that enables fine-tuning of edge deployments. By default, if wan_edges is
+# not specified, all devices from the PnP portal will be deployed. However, when wan_edges is defined, only listed
+# devices, excluding those marked with a foreign flag, will be deployed.
+#
+# Specifying the foreign, mgmt_public_ip, and transport_public_ip parameters indicates that the edge device has been
+# deployed elsewhere. In such cases Security Groups will be updated with the provided public IPs and the device will
+# be activated accordingly.
+#
+# Example usage:
+#   wan_edges:
+#     - uuid: DEVICE_UUID # this device will be deployed as usual
+#     - uuid: DEVICE_UUID # this device will be ignored during deployment
+#       foreign: true
+#     - uuid: DEVICE_UUID # this device will be treated as deployed outside of cluster
+#       foreign: true
+#       mgmt_public_ip: PUBLIC_IP
+#       transport_public_ip: PUBLIC_IP
+
 
 ##########################################
 #       Reusable deployment facts        #

--- a/playbooks/aws/deploy_edges.yml
+++ b/playbooks/aws/deploy_edges.yml
@@ -1,0 +1,25 @@
+# Copyright 2024 Cisco Systems, Inc. and its affiliates
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+# Deploy VPC and network infrastucture on AWS
+- name: Deploy Cisco SD-WAN versions 20.13 on AWS
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    ./aws_sdwan_config.yml
+  tasks:
+  roles:
+    - cisco.sdwan_deployment.aws_network_infrastructure
+
+
+# Deploying edges requires vbond_mgmt_public_ip, otp and uuid!
+- name: Deploy Edge devices based on generated boostrap configuration
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - ./aws_sdwan_config.yml
+    - "{{ results_path_controllers }}"
+    - "{{ deployment_edges_config }}"
+  roles:
+    - cisco.sdwan_deployment.aws_edges


### PR DESCRIPTION
# Pull Request summary:
This PR allow user to deploy only a subset of edges present in PnP portal.

# Description of changes:
New config option is introduced: wan_edges. When defined, edges synced from PnP portal will be filtered to devices present on the list.

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
