### PR TITLE
Deprecate aws_availibility_zone variable

### DIFF
--- a/playbooks/aws/aws_sdwan_config.yml
+++ b/playbooks/aws/aws_sdwan_config.yml
@@ -16,7 +16,6 @@ organization_name: null
 #####################################
 
 aws_region: us-east-1
-aws_availibility_zone: us-east-1a
 aws_resources_prefix: "{{ organization_name }}"
 
 # aws_allowed_subnets is list of subnets, that are allowed to access your instances via security group in AWS

--- a/playbooks/aws/test_variables.yml
+++ b/playbooks/aws/test_variables.yml
@@ -14,7 +14,6 @@
     required_variables:
       organization_name: "{{ organization_name | default() }}"
       aws_region: "{{ aws_region | default() }}"
-      aws_availibility_zone: "{{ aws_availibility_zone | default() }}"
       aws_allowed_subnets: "{{ aws_allowed_subnets | default() }}"
       aws_vmanage_ami_id: "{{ aws_vmanage_ami_id | default() }}"
       aws_vbond_ami_id: "{{ aws_vbond_ami_id | default() }}"


### PR DESCRIPTION
# Pull Request summary:
This PR removes aws_availibility_zone variable from available variables. Virtual machine will be created in default availability zone

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
