### PR TITLE
Launch AWS Edges in multiple AWS regions

### DIFF
--- a/playbooks/aws/aws_sdwan_config.yml
+++ b/playbooks/aws/aws_sdwan_config.yml
@@ -98,6 +98,9 @@ aws_cedge_instance_type: "c5.large"
 # deployed elsewhere. In such cases Security Groups will be updated with the provided public IPs and the device will
 # be activated accordingly.
 #
+# You can specify the aws_region and aws_cedge_ami_id parameters to create Edges in AWS regions different from the
+# controllers. Note that each AWS region has its own unique AMI IDs.
+#
 # Example usage:
 #   wan_edges:
 #     - uuid: DEVICE_UUID # this device will be deployed as usual


### PR DESCRIPTION
# Pull Request summary:
This PR enables users to create Edges in regions different from the control components. In each region, the base network infrastructure will be provisioned, including VPC, subnets, and security group.

# Description of changes:
The recently added wan_edges parameter has been enhanced with additional variables. Users can now specify aws_region and aws_cedge_ami_id to deploy edges in different AWS regions. Roles from the ansible-collection-sdwan-deployment will iterate over all specified regions during the creation and teardown of network infrastructure.

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
